### PR TITLE
Add optional `gems` input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,3 +7,8 @@ runs:
 branding:
   icon: 'tool'
   color: 'red'
+inputs:
+  gems:
+    description: 'String of gems to install'
+    required: false
+    default: ''

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,8 @@ cp /cookstyle.json ._actionshub_problem-matchers/cookstyle.json
 cp /rspec.json ._actionshub_problem-matchers/rspec.json
 echo "##[add-matcher]._actionshub_problem-matchers/cookstyle.json"
 echo "##[add-matcher]._actionshub_problem-matchers/rspec.json"
+if [ -n "${INPUT_GEMS}" ] ; then
+  echo "Installing gem(s): ${INPUT_GEMS}"
+  chef gem install -N "${INPUT_GEMS}"
+fi
 chef exec delivery local all


### PR DESCRIPTION
Sometimes cookbook ChefSpec tests require additional gem(s) to be installed to
test the code properly. This allows users to set what gem(s) to to be installed.

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
