### PR TITLE
Run rspec and cookstyle commands directly

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,5 @@ if [ -n "${INPUT_GEMS}" ] ; then
   echo "Installing gem(s): ${INPUT_GEMS}"
   chef gem install -N "${INPUT_GEMS}"
 fi
-chef exec delivery local all
+chef exec rspec spec/
+chef exec cookstyle --display-cop-names --extra-details


### PR DESCRIPTION
The delivery CLI has been EOL'd and removed from the latest workstation [1]. So instead just run rspec and cookstyle commands directly.

[1] https://discourse.chef.io/t/chef-workstation-22-1-778-released/20730#delivery-cli-removal-10

Signed-off-by: Lance Albertson <lance@osuosl.org>
